### PR TITLE
Fix out of bound

### DIFF
--- a/psets/ps5/pset5.ipynb
+++ b/psets/ps5/pset5.ipynb
@@ -485,22 +485,8 @@
     "# training on english\n",
     "dp = depp.DependencyParser(feature_function=DelexicalizedFeats())\n",
     "dp.read_data(\"english_univtags\")\n",
-    "dp.train_perceptron(10)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "# applying to the target language\n",
-    "new_dp = depp.DependencyParser(feature_function=DelexicalizedFeats())\n",
-    "new_dp.read_data(TARGET_LANGUAGE)\n",
-    "new_dp.setWeights (dp.weights)\n",
-    "new_dp.test(join (DIR, TARGET_LANGUAGE+\"_dev.conll\"), join (DIR, TARGET_LANGUAGE + \".deliverable2c.conll\"))\n",
+    "dp.train_perceptron(10)\n",
+    "dp.test(join (DIR, TARGET_LANGUAGE+\"_dev.conll\"), join (DIR, TARGET_LANGUAGE + \".deliverable2c.conll\"))\n",
     "print \"Accuracy:\", accuracy(join (DIR, TARGET_LANGUAGE+\"_dev.conll\"), join (DIR, TARGET_LANGUAGE + \".deliverable2c.conll\"))"
    ]
   },

--- a/psets/ps5/tests/test_deliverables.py
+++ b/psets/ps5/tests/test_deliverables.py
@@ -170,7 +170,7 @@ def test1_entropy_for_deliverable2b ():
     verb_distribution = utilities.CPT (dp.reader.train_instances, dp.reader.pos_dict['VB'])
     expected = 2.653
     actual = utilities.entropy (verb_distribution)
-    assert_almost_equals (expected , actual, places=3, msg="Entropy incorrect for 2b: Expected %f, Actual %f" %(expected, actual))
+    ok_ (expected < (actual + 0.002), msg="Entropy incorrect for 2b: Expected %f, Actual %f" %(expected, actual))
 
 def test2_entropy_for_deliverable2b ():
     dp = dependency_parser.DependencyParser(feature_function=dependency_features.DependencyFeatures())
@@ -178,7 +178,7 @@ def test2_entropy_for_deliverable2b ():
     verb_distribution = utilities.CPT (dp.reader.train_instances, dp.reader.pos_dict['VERB'])
     expected = 1.9
     actual = utilities.entropy (verb_distribution)
-    assert_almost_equals (expected , actual, places=3, msg="Entropy incorrect for 2b: Expected %f, Actual %f" %(expected, actual))
+    ok_ (expected < (actual + 0.002), msg="Entropy incorrect for 2b: Expected %f, Actual %f" %(expected, actual))
 
 def test_accuracy_for_deliverable2c ():
     expected = {GERMAN: 0.432, SPANISH:0.365 , ITALIAN: 0.311, FRENCH: 0.372, PORTO: 0.305}

--- a/psets/ps5/tests/test_deliverables.py
+++ b/psets/ps5/tests/test_deliverables.py
@@ -181,7 +181,7 @@ def test2_entropy_for_deliverable2b ():
     assert_almost_equals (expected , actual, places=3, msg="Entropy incorrect for 2b: Expected %f, Actual %f" %(expected, actual))
 
 def test_accuracy_for_deliverable2c ():
-    expected = {GERMAN: 0.287, SPANISH:0.093 , ITALIAN: 0.201, FRENCH: 0.244, PORTO: 0.290}
+    expected = {GERMAN: 0.432, SPANISH:0.365 , ITALIAN: 0.311, FRENCH: 0.372, PORTO: 0.305}
     SUFFIX = "deliverable2c.conll"
     lang, filename = getForeignLanguage (DIR, SUFFIX)
     actual   = accuracy (KEYFILES[lang], os.path.join (DIR, filename))


### PR DESCRIPTION
@jacobeisenstein Please review these fixes

- no use of ```new_dp``` variable in python notebook
- added some tolerance in entropy tests
- updated accuracy values for new test 2c 