### PR TITLE
fix shape of tensor in unit test

### DIFF
--- a/psets/ps2/tests/test_viterbi.py
+++ b/psets/ps2/tests/test_viterbi.py
@@ -73,7 +73,7 @@ def test_viterbi_step_init():
     eq_(bptrs[3],0)
     
     
-    prev_scores = torch.autograd.Variable(torch.from_numpy(np.array([-np.inf, -2, -13, -np.inf]).astype(np.float32))) 
+    prev_scores = torch.autograd.Variable(torch.from_numpy(np.array([-np.inf, -2, -13, -np.inf]).astype(np.float32))).view(1,-1) 
     viterbivars, bptrs = viterbi.viterbi_step(all_tags, tag_to_ix,
                                               emission_probs[1],
                                               tag_transition_probs,


### PR DESCRIPTION
changed the shape of the tensor `prev_scores` to be `[1,len(tags)]` as mentioned in the documentation of pset2. rechecked my code and works for all cases.