### PR TITLE
get rid of leftover pdb

### DIFF
--- a/psets/ps3/gtnlplib/evaluation.py
+++ b/psets/ps3/gtnlplib/evaluation.py
@@ -65,10 +65,7 @@ def compute_metric(parser, data, metric):
     for sentence, actions in data:
         if len(sentence) > 1:
             gold = dependency_graph_from_oracle(sentence, actions)
-            try:
-                predicted = parser.predict(sentence)
-            except:
-                import pdb; pdb.set_trace()
+            predicted = parser.predict(sentence)
             val += metric(predicted, gold)
     return val / len(data)
 


### PR DESCRIPTION
I accidentally left this pdb statement in the evaluation code that triggers when a student's parser malfunctions when not given gold actions. This gets rid of the pdb so that the code will error normally in those cases.